### PR TITLE
Add chmod command to set permissions for Colibre Dark icon zip file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,6 +29,7 @@ echo -e "\n=> 📥 Installing Libreoffice Colibre Dark\n"
 
 sudo mkdir -p -v "/usr/share/libreoffice/share/config"
 sudo cp -v "images_colibre_dark_svg.zip" "/usr/share/libreoffice/share/config/images_colibre_dark_svg.zip"
+sudo chmod 644 "/usr/share/libreoffice/share/config/images_colibre_dark_svg.zip"
 
 for dir in \
     /usr/lib64/libreoffice/share/config \


### PR DESCRIPTION
- Included a command to set the permissions of the "images_colibre_dark_svg.zip" file to 644.
- Ensures the file has the correct read permissions for all users after copying it to the "/usr/share/libreoffice/share/config" directory.